### PR TITLE
Fix blob server ID access by adding result key

### DIFF
--- a/lib/workflow.py
+++ b/lib/workflow.py
@@ -124,7 +124,7 @@ class Workflow:
 		configured_blob_server_id = \
 			self._manager_api.get_inherited_default_blob_server_id(
 				self._auth_context,
-				immediate_parent_dir['id'])
+				immediate_parent_dir['id'])["result"]
 
 		# Blob Server is a role of a Model Server, basically they are the same thing:
 		model_server = self._manager_api.get_resource_by_id(self._auth_context, configured_blob_server_id)


### PR DESCRIPTION
The get_inherited_default_blob_server_id API returns a result object, need to access the 'result' key to get the actual blob server ID.